### PR TITLE
Fix averages showing NaN for no transcriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tor-user-stats",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Inofficial unser stats for /r/TranscribersOfReddit",
   "main": "dist-cli/src/main.js",
   "author": "Tim Jentzsch",

--- a/src/analizer.ts
+++ b/src/analizer.ts
@@ -41,6 +41,17 @@ type TranscriptionAmount = {
  * @param transcriptions The transcriptions to analize.
  */
 export function getTranscriptionAmount(transcriptions: Transcription[]): TranscriptionAmount {
+  if (transcriptions.length === 0) {
+    return {
+      charTotal: 0,
+      charAvg: 0,
+      charPeak: 0,
+      wordTotal: 0,
+      wordAvg: 0,
+      wordPeak: 0,
+    };
+  }
+
   const count = transcriptions.length;
 
   let charTotal = 0;

--- a/src/analizer.ts
+++ b/src/analizer.ts
@@ -1,12 +1,13 @@
 import { Comment } from 'snoowrap';
 import Logger from './logger';
-import { getAllUserComments, isToRMod } from './reddit-api';
+import { getAllUserComments } from './reddit-api';
 import { gammaAvg, karmaAvg } from './stats/avg';
+import { getTranscriptionLength } from './stats/length';
 import { gammaPeak, karmaPeak } from './stats/peak';
 import { subredditGamma, subredditKarma } from './stats/subreddits';
 import { getCountTag, getModTag, getSpecialTags } from './stats/tags';
 import { formatGamma, typeGamma, formatKarma, typeKarma } from './stats/type';
-import { CountTag, specialTags, countTagList, Tag } from './tags';
+import { Tag } from './tags';
 import Transcription from './transcription';
 import { limitEnd } from './util';
 
@@ -19,66 +20,6 @@ export function isComment(comment: Comment): boolean {
     // Has one of the bot keywords
     /\b(done|(un)?claim(ing)?)\b/.test(comment.body)
   );
-}
-
-type TranscriptionAmount = {
-  /** The total number of characters. */
-  charTotal: number;
-  /** The average number of characters. */
-  charAvg: number;
-  /** The maximum amount of characters. */
-  charPeak: number;
-  /** The total number of words. */
-  wordTotal: number;
-  /** The average number of words. */
-  wordAvg: number;
-  /** The maximum amount of words. */
-  wordPeak: number;
-};
-
-/**
- * Analyzes the character and word count of the transcriptions.
- * @param transcriptions The transcriptions to analize.
- */
-export function getTranscriptionAmount(transcriptions: Transcription[]): TranscriptionAmount {
-  if (transcriptions.length === 0) {
-    return {
-      charTotal: 0,
-      charAvg: 0,
-      charPeak: 0,
-      wordTotal: 0,
-      wordAvg: 0,
-      wordPeak: 0,
-    };
-  }
-
-  const count = transcriptions.length;
-
-  let charTotal = 0;
-  let charPeak = 0;
-  let wordTotal = 0;
-  let wordPeak = 0;
-
-  transcriptions.forEach((transcrition) => {
-    // Determine character and word count of this transcriptions
-    const charCount = transcrition.contentMD.length;
-    const wordCount = transcrition.contentMD.split(/\s+/).length;
-
-    charTotal += charCount;
-    charPeak = Math.max(charPeak, charCount);
-
-    wordTotal += wordCount;
-    wordPeak = Math.max(wordPeak, wordCount);
-  });
-
-  return {
-    charTotal,
-    charAvg: charTotal / count,
-    charPeak,
-    wordTotal,
-    wordAvg: wordTotal / count,
-    wordPeak,
-  };
 }
 
 export function logStats(label: string, stats: string): void {
@@ -174,7 +115,7 @@ export default async function analizeUser(userName: string): Promise<void> {
   );
 
   // Amounts
-  const amounts = getTranscriptionAmount(transcriptions);
+  const amounts = getTranscriptionLength(transcriptions);
 
   logStats(
     'Chars',

--- a/src/stats/length.ts
+++ b/src/stats/length.ts
@@ -1,0 +1,61 @@
+import Transcription from '../transcription';
+
+export type TranscriptionLength = {
+  /** The total number of characters. */
+  charTotal: number;
+  /** The average number of characters. */
+  charAvg: number;
+  /** The maximum amount of characters. */
+  charPeak: number;
+  /** The total number of words. */
+  wordTotal: number;
+  /** The average number of words. */
+  wordAvg: number;
+  /** The maximum amount of words. */
+  wordPeak: number;
+};
+
+/**
+ * Analyzes the character and word count of the transcriptions.
+ * @param transcriptions The transcriptions to analize.
+ */
+export function getTranscriptionLength(transcriptions: Transcription[]): TranscriptionLength {
+  if (transcriptions.length === 0) {
+    return {
+      charTotal: 0,
+      charAvg: 0,
+      charPeak: 0,
+      wordTotal: 0,
+      wordAvg: 0,
+      wordPeak: 0,
+    };
+  }
+
+  const count = transcriptions.length;
+
+  let charTotal = 0;
+  let charPeak = 0;
+  let wordTotal = 0;
+  let wordPeak = 0;
+
+  transcriptions.forEach((transcrition) => {
+    // Determine character and word count of this transcriptions
+    const charCount = transcrition.contentMD.length;
+    const wordCount = transcrition.contentMD.split(/\s+/).length;
+
+    charTotal += charCount;
+    charPeak = Math.max(charPeak, charCount);
+
+    wordTotal += wordCount;
+    wordPeak = Math.max(wordPeak, wordCount);
+  });
+
+  return {
+    charTotal,
+    charAvg: charTotal / count,
+    charPeak,
+    wordTotal,
+    wordAvg: wordTotal / count,
+    wordPeak,
+  };
+}

--- a/src/stats/tags.ts
+++ b/src/stats/tags.ts
@@ -53,6 +53,10 @@ export function getTwentyFourTag(transcriptions: Transcription[]): Tag | null {
  * @param transcriptions The transcriptions to analyze.
  */
 export function getBetaTesterTag(transcriptions: Transcription[]): Tag | null {
+  if (transcriptions.length === 0) {
+    return null;
+  }
+
   // The end of the beta
   const betaDate = new Date('2021-12-31T00:00:00').valueOf() / 1000;
   // The time of the first transcription

--- a/src/user-display.ts
+++ b/src/user-display.ts
@@ -1,5 +1,5 @@
 import { getAllUserComments } from './reddit-api';
-import { getTranscriptionAmount, isComment } from './analizer';
+import { isComment } from './analizer';
 import Transcription from './transcription';
 import {
   formatGammaDiagram,
@@ -19,6 +19,7 @@ import { displayHeatmap, initHeatmapTable } from './display/heatmap';
 import { updateElement } from './display/display-util';
 import { displayHallOfFame, displayRecent } from './display/hall-of-fame';
 import { displayModTag, displayTags } from './display/tags';
+import { getTranscriptionLength } from './stats/length';
 
 function searchUserHeader() {
   const input = document.getElementById('header-user-input') as HTMLInputElement;
@@ -145,7 +146,7 @@ function updateAvgs(transcriptions: Transcription[]) {
 }
 
 function updateCharWords(transcriptions: Transcription[]) {
-  const amounts = getTranscriptionAmount(transcriptions);
+  const amounts = getTranscriptionLength(transcriptions);
 
   updateElement('char-total', amounts.charTotal);
   updateElement('char-peak', amounts.charPeak);

--- a/styles/main.css
+++ b/styles/main.css
@@ -426,7 +426,7 @@ td {
 }
 
 .twenty-four {
-  background-color: var(--twentyFour);
+  background-color: var(--twenty-four);
 }
 .beta-tester {
   background-color: var(--beta-tester);

--- a/templates/user.html
+++ b/templates/user.html
@@ -69,10 +69,10 @@
             </tr>
             <tr>
               <th class="right-th">Average</th>
-              <td id="gamma-avg-1h">0</td>
-              <td id="gamma-avg-24h">0</td>
-              <td id="gamma-avg-7d">0</td>
-              <td id="gamma-avg-365d">0</td>
+              <td id="gamma-avg-1h">0.00</td>
+              <td id="gamma-avg-24h">0.00</td>
+              <td id="gamma-avg-7d">0.00</td>
+              <td id="gamma-avg-365d">0.00</td>
             </tr>
           </table>
           <table>
@@ -95,10 +95,10 @@
             </tr>
             <tr>
               <th class="right-th">Average</th>
-              <td id="karma-avg-1h">0</td>
-              <td id="karma-avg-24h">0</td>
-              <td id="karma-avg-7d">0</td>
-              <td id="karma-avg-365d">0</td>
+              <td id="karma-avg-1h">0.00</td>
+              <td id="karma-avg-24h">0.00</td>
+              <td id="karma-avg-7d">0.00</td>
+              <td id="karma-avg-365d">0.00</td>
             </tr>
           </table>
           <table>
@@ -115,13 +115,13 @@
               <th class="right-th">Characters</th>
               <td id="char-total">0</td>
               <td id="char-peak">0</td>
-              <td id="char-avg">0</td>
+              <td id="char-avg">0.00</td>
             </tr>
             <tr>
               <th class="right-th">Words</th>
               <td id="word-total">0</td>
               <td id="word-peak">0</td>
-              <td id="word-avg">0</td>
+              <td id="word-avg">0.00</td>
             </tr>
           </table>
         </div>

--- a/tests/stats/length.test.ts
+++ b/tests/stats/length.test.ts
@@ -1,0 +1,50 @@
+import { getTranscriptionLength, TranscriptionLength } from '../../src/stats/length';
+import Transcription from '../../src/transcription';
+import { imageMD } from '../transcription-templates';
+
+describe('Transcription length', () => {
+  // Transcription length
+  describe('getTranscriptionLength', () => {
+    test('should return 0 for no transcriptions', () => {
+      const transcriptions: Transcription[] = [];
+      const expected: TranscriptionLength = {
+        charAvg: 0,
+        charPeak: 0,
+        charTotal: 0,
+        wordAvg: 0,
+        wordPeak: 0,
+        wordTotal: 0,
+      };
+
+      const actual = getTranscriptionLength(transcriptions);
+
+      expect(actual).toEqual(expected);
+    });
+
+    test('should return length for single transcription', () => {
+      const transcriptions: Transcription[] = [
+        new Transcription(
+          '1',
+          '',
+          imageMD,
+          '',
+          new Date('2020-11-01').valueOf() / 1000,
+          1,
+          'r/me_irl',
+        ),
+      ];
+      const expected: TranscriptionLength = {
+        charAvg: 359,
+        charPeak: 359,
+        charTotal: 359,
+        wordAvg: 61,
+        wordPeak: 61,
+        wordTotal: 61,
+      };
+
+      const actual = getTranscriptionLength(transcriptions);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/tests/stats/tags.test.ts
+++ b/tests/stats/tags.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable jest/expect-expect */
 import { getBetaTesterTag, getCountTag, getTwentyFourTag } from '../../src/stats/tags';
 import { countTags, specialTags, Tag } from '../../src/tags';
+import Transcription from '../../src/transcription';
 import TranscriptionGenerator from '../transcription-generator';
 
 /** Asserts that the given tag is assigned for the given count. */
@@ -87,6 +88,14 @@ describe('Tag Stats', () => {
         .addTranscriptions(1, 0)
         .generate();
       const expected = specialTags.betaTester;
+      const actual = getBetaTesterTag(transcriptions);
+
+      expect(actual).toEqual(expected);
+    });
+
+    test('should return null for no transcriptions', () => {
+      const transcriptions: Transcription[] = [];
+      const expected = null;
       const actual = getBetaTesterTag(transcriptions);
 
       expect(actual).toEqual(expected);


### PR DESCRIPTION
- Fixes averages showing `NaN` for no transcriptions
- Fixes 100/24h tag color
- Fixes beta tag giving error for no transcriptions
- Add transcription length tests

Closes #41.